### PR TITLE
debian: mkdir /etc/bash_completion.d

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Architecture: all
 Depends:
  ${python3:Depends},
  ${misc:Depends},
- bash-completion,
  python3-cliff,
  wazo-auth-client-python3,
  xivo-lib-python-python3

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,1 +1,2 @@
+etc/bash_completion.d
 etc/wazo-auth-cli/conf.d


### PR DESCRIPTION
reason: bash-completion package doesn't create /etc/bash_completion.d
directory. According to the current install, each package that provide
some scripts, create the bash_completion.d directory.

On wazo-platform 19.14:
$ dpkg -S /etc/bash_completion.d/
fail2ban, git, dahdi: /etc/bash_completion.d