### PR TITLE
WAZO-1689 Pull request for WAZO-1690-auth-http

### DIFF
--- a/etc/wazo-auth-cli/config.yml
+++ b/etc/wazo-auth-cli/config.yml
@@ -4,4 +4,5 @@ extra_config_files: '/etc/wazo-auth-cli/conf.d'
 auth:
   host: localhost
   port: 9497
-  verify_certificate: /usr/share/xivo-certs/server.crt
+  prefix: null
+  https: false

--- a/wazo_auth_cli/commands/group.py
+++ b/wazo_auth_cli/commands/group.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -71,7 +71,7 @@ class GroupCreate(TenantIdentifierMixin, Command):
 
     def take_action(self, parsed_args):
         self.app.LOG.debug(parsed_args)
-        body = dict(name=parsed_args.name,)
+        body = {'name': parsed_args.name}
 
         if parsed_args.tenant:
             tenant_uuid = self.get_tenant_uuid(self.app.client, parsed_args.tenant)

--- a/wazo_auth_cli/commands/user.py
+++ b/wazo_auth_cli/commands/user.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -67,7 +67,7 @@ class UserCreate(TenantIdentifierMixin, Command):
 
     def take_action(self, parsed_args):
         self.app.LOG.debug(parsed_args)
-        body = dict(username=parsed_args.name, password=parsed_args.password,)
+        body = {'username': parsed_args.name, 'password': parsed_args.password}
         if parsed_args.uuid:
             body['uuid'] = parsed_args.uuid
         if parsed_args.email:

--- a/wazo_auth_cli/config.py
+++ b/wazo_auth_cli/config.py
@@ -12,7 +12,7 @@ _APP_NAME = 'wazo-auth-cli'
 _DEFAULT_CONFIG = {
     'config_file': '/etc/{}/config.yml'.format(_APP_NAME),
     'extra_config_files': '/etc/{}/conf.d/'.format(_APP_NAME),
-    'auth': {'host': 'localhost', 'port': 9497, 'verify_certificate': True},
+    'auth': {'host': 'localhost', 'port': 9497, 'prefix': None, 'https': False},
 }
 
 _AUTH_ARGS_TO_FIELDS_MAP = {
@@ -33,6 +33,8 @@ def _args_to_dict(parsed_args):
         logger.debug('setting %s = %s', config_name, value)
         auth_config[config_name] = value
 
+    if parsed_args.ssl:
+        auth_config['https'] = True
     if parsed_args.no_ssl:
         auth_config['https'] = False
     if parsed_args.verify:

--- a/wazo_auth_cli/config.py
+++ b/wazo_auth_cli/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -9,24 +9,23 @@ from xivo.config_helper import parse_config_dir, read_config_file_hierarchy
 logger = logging.getLogger(__name__)
 
 _APP_NAME = 'wazo-auth-cli'
-_DEFAULT_AUTH_CONFIG = dict(host='localhost', port=9497, verify_certificate=True,)
-_DEFAULT_CONFIG = dict(
-    config_file='/etc/{}/config.yml'.format(_APP_NAME),
-    extra_config_files='/etc/{}/conf.d/'.format(_APP_NAME),
-    auth=_DEFAULT_AUTH_CONFIG,
-)
+_DEFAULT_CONFIG = {
+    'config_file': '/etc/{}/config.yml'.format(_APP_NAME),
+    'extra_config_files': '/etc/{}/conf.d/'.format(_APP_NAME),
+    'auth': {'host': 'localhost', 'port': 9497, 'verify_certificate': True},
+}
 
-_AUTH_ARGS_TO_FIELDS_MAP = dict(
-    auth_username='username',
-    hostname='host',
-    auth_password='password',
-    port='port',
-    backend='backend',
-)
+_AUTH_ARGS_TO_FIELDS_MAP = {
+    'auth_username': 'username',
+    'hostname': 'host',
+    'auth_password': 'password',
+    'port': 'port',
+    'backend': 'backend',
+}
 
 
 def _args_to_dict(parsed_args):
-    auth_config = dict()
+    auth_config = {}
     for arg_name, config_name in _AUTH_ARGS_TO_FIELDS_MAP.items():
         value = getattr(parsed_args, arg_name, None)
         if value is None:
@@ -41,7 +40,7 @@ def _args_to_dict(parsed_args):
     elif parsed_args.cacert:
         auth_config['verify_certificate'] = parsed_args.cacert
 
-    config = dict(auth=auth_config)
+    config = {'auth': auth_config}
     return config
 
 

--- a/wazo_auth_cli/config.py
+++ b/wazo_auth_cli/config.py
@@ -33,6 +33,8 @@ def _args_to_dict(parsed_args):
         logger.debug('setting %s = %s', config_name, value)
         auth_config[config_name] = value
 
+    if parsed_args.no_ssl:
+        auth_config['https'] = False
     if parsed_args.verify:
         auth_config['verify_certificate'] = True
     elif parsed_args.insecure:

--- a/wazo_auth_cli/main.py
+++ b/wazo_auth_cli/main.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -45,6 +45,7 @@ class WazoAuthCLI(App):
         parser.add_argument('--port', help='The wazo-auth port')
 
         https_verification = parser.add_mutually_exclusive_group()
+        https_verification.add_argument('--no-ssl', help="Don't use ssl")
         https_verification.add_argument(
             '--verify', action='store_true', help='Verify the HTTPS certificate or not'
         )

--- a/wazo_auth_cli/main.py
+++ b/wazo_auth_cli/main.py
@@ -45,6 +45,7 @@ class WazoAuthCLI(App):
         parser.add_argument('--port', help='The wazo-auth port')
 
         https_verification = parser.add_mutually_exclusive_group()
+        https_verification.add_argument('--ssl', help="Use ssl")
         https_verification.add_argument('--no-ssl', help="Don't use ssl")
         https_verification.add_argument(
             '--verify', action='store_true', help='Verify the HTTPS certificate or not'


### PR DESCRIPTION
use auth without ssl by default
Allow to disable ssl
use {} instead dict()