### PR TITLE
remove deprecated acl_templates

### DIFF
--- a/wazo_auth_cli/commands/policy.py
+++ b/wazo_auth_cli/commands/policy.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -77,7 +77,7 @@ class PolicyList(ListBuildingMixin, TenantIdentifierMixin, Lister):
     "List all policies available"
 
     _columns = ['uuid', 'name', 'description', 'tenant_uuid']
-    _removed_columns = ['acl_templates', 'acl']
+    _removed_columns = ['acl']
 
     def get_parser(self, *args, **kwargs):
         parser = super().get_parser(*args, **kwargs)
@@ -115,5 +115,4 @@ class PolicyShow(PolicyIdentifierMixin, Command):
     def take_action(self, parsed_args):
         uuid = self.get_policy_uuid(self.app.client, parsed_args.identifier)
         policy = self.app.client.policies.get(uuid)
-        del policy['acl_templates']
         self.app.stdout.write(json.dumps(policy, indent=True, sort_keys=True) + '\n')


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-auth/pull/144