### PR TITLE
docker: fix user config override system config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN python setup.py install
 FROM python:3.7-slim-buster AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
 
-ENV WAZO_AUTH_CLI_CONFIG=/etc/wazo-auth-cli
-
 COPY ./etc/wazo-auth-cli /etc/wazo-auth-cli
 RUN true \
-    && mkdir -p /etc/wazo-auth-cli/conf.d
+    && mkdir -p /etc/wazo-auth-cli/conf.d \
+    # create empty config dir to avoid override system config
+    && mkdir -p /root/.config/wazo-auth-cli
 
 # Activate virtual env
 ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
WAZO_AUTH_CLI_CONFIG variable is considered as "user configuration".
Then everything in this directory have more priority than "system
configuration". But "user configuration" doesn't read
"extra_config_dir" or subdirectory

If WAZO_AUTH_CLI_CONFIG is set to the default system configuration
directory, then all options in /etc/wazo-auth-cli/config.yml will be
prioritized over others options in conf.d

Adding an empty "user configuration" directory only skip it and take all
"system configuration" (i.e. config.yml + conf.d/*)