### PR TITLE
remove deprecated endpoint now removed

### DIFF
--- a/wazo_auth_cli/commands/user.py
+++ b/wazo_auth_cli/commands/user.py
@@ -248,7 +248,6 @@ class UserShow(UserIdentifierMixin, Command):
         uuid = self.get_user_uuid(self.app.client, parsed_args.identifier)
         user = self.app.client.users.get(uuid)
         user['policies'] = self.app.client.users.get_policies(uuid)['items']
-        user['tenants'] = self.app.client.users.get_tenants(uuid)['items']
         user['groups'] = self.app.client.users.get_groups(uuid)['items']
         user['sessions'] = self.app.client.users.get_sessions(uuid)['items']
         self.app.stdout.write(json.dumps(user, indent=True, sort_keys=True) + '\n')


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-auth-client/pull/43