### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/etc/wazo-auth-cli/config.yml
+++ b/etc/wazo-auth-cli/config.yml
@@ -3,6 +3,5 @@ extra_config_files: '/etc/wazo-auth-cli/conf.d'
 # Connection info to the authentication server
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false

--- a/wazo_auth_cli/config.py
+++ b/wazo_auth_cli/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -12,7 +12,7 @@ _APP_NAME = 'wazo-auth-cli'
 _DEFAULT_CONFIG = {
     'config_file': f'/etc/{_APP_NAME}/config.yml',
     'extra_config_files': f'/etc/{_APP_NAME}/conf.d/',
-    'auth': {'host': 'localhost', 'port': 9497, 'prefix': None, 'https': False},
+    'auth': {'host': 'localhost', 'port': 80, 'https': False},
 }
 
 _AUTH_ARGS_TO_FIELDS_MAP = {


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth CLI connectivity depends on deploying nginx and wazo-auth changes first; mis-ordering causes internal auth requests to fail (e.g. 404).
> 
> **Overview**
> **wazo-auth-cli** now targets the nginx internal auth entry point instead of the wazo-auth process directly.
> 
> Default and shipped `auth` settings change **port** from `9497` to `80` on `localhost`, and the explicit `prefix: null` override is removed so **`wazo-auth-client`** uses its built-in `/api/auth` path. Python `_DEFAULT_CONFIG` and `etc/wazo-auth-cli/config.yml` are updated together so layered config stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85917ef6068405f7bef3bf89ada7085a92eea06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->